### PR TITLE
[CHORE][IOS]Update Telereso.podspec

### DIFF
--- a/Telereso.podspec
+++ b/Telereso.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'Telereso'
-  s.version          = '0.0.6'
+  s.version          = '0.0.7-alpha'
   s.summary          = 'Control your app resources remotely.'
 
 # This description is used to generate tags and improve search results.
@@ -45,5 +45,12 @@ currently support string localization, in upcoming versions will support images 
   s.dependency 'Firebase/RemoteConfig', '8.14.0'
   s.dependency 'SwiftyJSON', '>= 4.0'
   s.dependency 'SDWebImage'
+  
+  s.pod_target_xcconfig = {
+    'FRAMEWORK_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/Firebase $(PODS_ROOT)/FirebaseCore/Frameworks $(PODS_ROOT)/FirebaseRemoteConfig/Frameworks'
+
+  s.pod_target_xcconfig = {
+    'OTHER_LDFLAGS' => '$(inherited) -ObjC'
+  }
 
 end


### PR DESCRIPTION
Add target_xcconfig to fix error

Undefined symbols for architecture x86_64:
  "OBJC_CLASS$_FIRRemoteConfigSettings", referenced from:
      objc-class-ref in Telereso.o
  "OBJC_CLASS$_FIRRemoteConfig", referenced from:
      objc-class-ref in Telereso.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)